### PR TITLE
Implement manual value handling

### DIFF
--- a/ExcelLookup.cs
+++ b/ExcelLookup.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using OfficeOpenXml;
 
@@ -24,6 +25,9 @@ namespace UpdateDimLabels
                     string key = sheet.Cells[r, 1].Text.Trim();
                     string val = sheet.Cells[r, 2].Text.Trim();
 
+                    if (double.TryParse(key, out double num))
+                        key = Helpers.FormatDim(num);
+
                     if (key.Length != 0 && !_map.ContainsKey(key))
                         _map.Add(key, val);
                 }
@@ -33,6 +37,9 @@ namespace UpdateDimLabels
         /// returns replacement or original value if not found
         public string Lookup(string value)
         {
+            if (double.TryParse(value, out double num))
+                value = Helpers.FormatDim(num);
+
             string replacement;
             return _map.TryGetValue(value, out replacement) ? replacement : value;
         }

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.Gis.Map.ObjectData;
@@ -25,6 +26,12 @@ namespace UpdateDimLabels
         {
             string result;
             return dict != null && dict.TryGetValue(key, out result) ? result : "";
+        }
+
+        public static string FormatDim(double value)
+        {
+            double rounded = Math.Round(value, 2, MidpointRounding.AwayFromZero);
+            return rounded.ToString("0.00");
         }
 
         /// Reads the *first* Object‑Data record on <ent>.

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -91,13 +91,42 @@ namespace UpdateDimLabels
                 // corrections -----------------------------------------------------
                 dispNum = Helpers.InsertSpaceInDispNum(dispNum); // LOC 123456
                 company = _company.Lookup(company);              // CNRL (or raw)
-                purpcd = _purpose.Lookup(purpcd);               // P/L R/W (or raw)
+                string lookedUpPurpose = _purpose.Lookup(purpcd);               // P/L R/W (or raw)
+                if (lookedUpPurpose == purpcd)
+                {
+                    ed.WriteMessage($"\nWarning: pipe-class '{purpcd}' not mapped; using default.");
+                    lookedUpPurpose = "P/L R/W";
+                }
+                purpcd = lookedUpPurpose;
 
                 // build text override  -------------------------------------------
-                string measurement = dim.Measurement.ToString("0.00");
+                string measurement;
+                string overrideText = dim.DimensionText;
+                string parsedToken = null;
+                if (!string.IsNullOrWhiteSpace(overrideText))
+                {
+                    var parts = overrideText.Split(new[] { "\X" }, StringSplitOptions.None);
+                    if (parts.Length >= 2)
+                    {
+                        var token = parts[1].Trim().Split(' ')[0];
+                        if (double.TryParse(token, out double existing))
+                            parsedToken = token;
+                    }
+                }
+
+                if (parsedToken != null)
+                {
+                    measurement = Helpers.FormatDim(double.Parse(parsedToken));
+                    ed.WriteMessage("\nUsing manual dimension value: " + measurement);
+                }
+                else
+                {
+                    measurement = Helpers.FormatDim(dim.Measurement);
+                }
+
                 string newText =
-                    company + "\\X" +
-                    measurement + " " + purpcd + "\\X" +
+                    company + "\X" +
+                    measurement + " " + purpcd + "\X" +
                     dispNum;
 
                 dim.DimensionText = newText;   // override


### PR DESCRIPTION
## Summary
- add Helpers.FormatDim and use it in ExcelLookup
- keep manually edited dimension values when updating
- warn and default when pipe-class lookup fails

## Testing
- `dotnet build -c Release` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9ac946608322b135cbc4125882e7