### PR TITLE
Fix rounding for dimension leader

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -278,7 +278,19 @@ namespace UpdateDimLabels
                                          .TransactionManager.StartTransaction())
                 {
                     var dim = (Dimension)tr.GetObject(per.ObjectId, OpenMode.ForWrite);
-                    string rounded = Helpers.RoundDimLeader(dim.Measurement);
+
+                    double currentValue;
+                    if (!string.IsNullOrWhiteSpace(dim.DimensionText) &&
+                        double.TryParse(dim.DimensionText, out var parsed))
+                    {
+                        currentValue = parsed;
+                    }
+                    else
+                    {
+                        currentValue = dim.Measurement;
+                    }
+
+                    string rounded = Helpers.RoundDimLeader(currentValue);
                     dim.DimensionText = rounded;
 
                     tr.Commit();


### PR DESCRIPTION
## Summary
- adjust the `UPDLDR` command to parse existing dimension text
- round the parsed value (or measurement) to the nearest allowed value

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687112cbe12883229edeb959736f7f0b