### PR TITLE
Add Fody Costura to bundle dependencies

### DIFF
--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,0 +1,3 @@
+<Weavers>
+  <Costura CreateTemporaryAssemblies="false"/>
+</Weavers>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ```bash
 dotnet build -c Release            # builds net48 + net8.0-windows
 # The ready-to-use plugin appears in: UpdateDimLabels.bundle
+# Fody/Costura merges EPPlus so only `UpdateDimLabels.dll` is needed
 # Copy that folder to C:\ProgramData\Autodesk\ApplicationPlugins
 ```
 
@@ -16,8 +17,8 @@ This AutoCAD Map 3D plug‑in adds the `UPDDIM` command which updates an aligned
 
 1. Open `UpdateDimLabels.sln` in Visual Studio 2022 or newer.
 2. Build the **Release|x64** configuration.
-   All required dependency DLLs will be copied to the output folder
-   (`bin\x64\Release`).
+   Fody runs automatically and merges all required DLLs into
+   `UpdateDimLabels.dll` in the output folder (`bin\x64\Release`).
 3. Copy `CompanyLookup.xlsx` and `PurposeLookup.xlsx` to the output
    folder next to `UpdateDimLabels.dll`.
 

--- a/UpdateDimLabels.csproj
+++ b/UpdateDimLabels.csproj
@@ -62,6 +62,9 @@
   <!-- ───────────── NuGet packages ───────────── -->
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="8.0.3" />
+    <!-- merge dependencies into single DLL -->
+    <PackageReference Include="Fody" Version="6.7.0" PrivateAssets="all" />
+    <PackageReference Include="Costura.Fody" Version="5.8.0" PrivateAssets="all" />
     <!-- needed for Encoding.RegisterProvider(...) on net8 -->
     <PackageReference Include="System.Text.Encoding.CodePages"
                       Version="8.0.0"
@@ -79,7 +82,6 @@
 
     <ItemGroup>
       <_Copy Include="$(TargetDir)UpdateDimLabels.dll" />
-      <_Copy Include="$(TargetDir)EPPlus*.dll" />   <!-- wildcard ≙ never breaks -->
     </ItemGroup>
 
     <Copy SourceFiles="@(_Copy)" DestinationFolder="$(BundleDir)" />
@@ -95,7 +97,6 @@
 
     <ItemGroup>
       <_Copy Include="$(TargetDir)UpdateDimLabels.dll" />
-      <_Copy Include="$(TargetDir)EPPlus*.dll" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_Copy)" DestinationFolder="$(BundleDir)" />


### PR DESCRIPTION
## Summary
- add Fody/Costura packages and config to merge dependencies into one DLL
- stop copying EPPlus separately
- mention single-DLL build in README

## Testing
- ❌ `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711411bd4c8322bafe6d8b903c456f