### PR TITLE
feat: always round numeric dimension text in UPDDIM

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -102,11 +102,14 @@ namespace UpdateDimLabels
 
                     // ── 4. Decide what to use as the “measurement” text ───────────
                     string measurement;
+                    double raw;
                     if (!string.IsNullOrWhiteSpace(dim.DimensionText) &&
-                        !dim.DimensionText.Contains("\\")) // no control codes → user override
+                        !dim.DimensionText.Contains("\\") &&
+                        double.TryParse(dim.DimensionText, out raw))
                     {
-                        measurement = dim.DimensionText;
-                        ed.WriteMessage("\nUsing manual dimension text: " + measurement);
+                        // manual text is numeric → round it
+                        measurement = Helpers.RoundDimLeader(raw);
+                        ed.WriteMessage($"\nRounded manual dimension text: {measurement}");
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- add rounding for numeric manual dimension text in `UPDDIM`
- always use `Helpers.RoundDimLeader()`

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688006a6a6dc8322bf11f4662a49e427